### PR TITLE
added the ability to track the location of errors in included files

### DIFF
--- a/Assembler/Spect.Net.Assembler/Assembler/AssemblerErrorInfo.cs
+++ b/Assembler/Spect.Net.Assembler/Assembler/AssemblerErrorInfo.cs
@@ -13,6 +13,11 @@ namespace Spect.Net.Assembler.Assembler
         public string ErrorCode { get; }
 
         /// <summary>
+        /// Source file in which the error occurred
+        /// </summary>
+        public string Filename { get; }
+
+        /// <summary>
         /// Source line of the error
         /// </summary>
         public int Line { get; }
@@ -27,23 +32,25 @@ namespace Spect.Net.Assembler.Assembler
         /// </summary>
         public string Message { get; }
 
-        public AssemblerErrorInfo(Z80AsmParserErrorInfo syntaxErrorInfo)
+        public AssemblerErrorInfo(SourceFileItem sourceItem, Z80AsmParserErrorInfo syntaxErrorInfo)
         {
             var token = syntaxErrorInfo.Token.Trim();
-            ErrorCode = token.Length == 0 
-                ? Errors.Z0101 
+            ErrorCode = token.Length == 0
+                ? Errors.Z0101
                 : Errors.Z0100;
             Line = syntaxErrorInfo.SourceLine;
             Column = syntaxErrorInfo.Position;
             Message = Errors.GetMessage(ErrorCode, token);
+            Filename = sourceItem.Filename;
         }
 
-        public AssemblerErrorInfo(string errorCode, SourceLineBase line, params object[] parameters)
+        public AssemblerErrorInfo(SourceFileItem sourceItem, string errorCode, SourceLineBase line, params object[] parameters)
         {
             ErrorCode = errorCode;
             Line = line.SourceLine;
             Column = line.Position;
             Message = Errors.GetMessage(ErrorCode, parameters);
+            Filename = sourceItem.Filename;
         }
     }
 }

--- a/Assembler/Spect.Net.Assembler/Assembler/Z80Assembler.cs
+++ b/Assembler/Spect.Net.Assembler/Assembler/Z80Assembler.cs
@@ -70,9 +70,8 @@ namespace Spect.Net.Assembler.Assembler
         /// <returns>
         /// Output of the compilation
         /// </returns>
-        public AssemblerOutput Compile(string sourceText, AssemblerOptions options = null) 
+        public AssemblerOutput Compile(string sourceText, AssemblerOptions options = null)
             => DoCompile(new SourceFileItem(NOFILE_ITEM), sourceText, options);
-
 
         /// <summary>
         /// This method compiles the passed Z80 Assembly code into Z80
@@ -88,7 +87,7 @@ namespace Spect.Net.Assembler.Assembler
         /// <returns>
         /// Output of the compilation
         /// </returns>
-        private AssemblerOutput DoCompile(SourceFileItem sourceItem, string sourceText, 
+        private AssemblerOutput DoCompile(SourceFileItem sourceItem, string sourceText,
             AssemblerOptions options = null)
         {
             // --- Init the compilation process
@@ -122,7 +121,7 @@ namespace Spect.Net.Assembler.Assembler
         /// <param name="sourceText">Source text to parse</param>
         /// <param name="parsedLines"></param>
         /// <returns>True, if parsing was successful</returns>
-        private bool ExecuteParse(int fileIndex, SourceFileItem sourceItem, string sourceText, 
+        private bool ExecuteParse(int fileIndex, SourceFileItem sourceItem, string sourceText,
             out List<SourceLineBase> parsedLines)
         {
             // --- No lines has been parsed yet
@@ -141,7 +140,7 @@ namespace Spect.Net.Assembler.Assembler
             // --- Collect syntax errors
             foreach (var error in parser.SyntaxErrors)
             {
-                ReportError(error);
+                ReportError(sourceItem, error);
             }
 
             // --- Exit if there are any errors
@@ -200,7 +199,7 @@ namespace Spect.Net.Assembler.Assembler
         /// <param name="incDirective">Directive with the file</param>
         /// <param name="sourceItem">Source file item</param>
         /// <param name="parsedLines">Collection of source code lines</param>
-        private bool ApplyIncludeDirective(int fileIndex, IncludeDirective incDirective, 
+        private bool ApplyIncludeDirective(int fileIndex, IncludeDirective incDirective,
             SourceFileItem sourceItem,
             out List<SourceLineBase> parsedLines)
         {
@@ -285,7 +284,7 @@ namespace Spect.Net.Assembler.Assembler
                 // --- Remove a symbol
                 if (processOps) ConditionSymbols.Remove(directive.Identifier);
             }
-            else if (directive.Mnemonic == "#IFDEF" || directive.Mnemonic == "#IFNDEF" 
+            else if (directive.Mnemonic == "#IFDEF" || directive.Mnemonic == "#IFNDEF"
                 || directive.Mnemonic == "#IF")
             {
                 // --- Evaluate the condition and stop/start processing
@@ -348,16 +347,17 @@ namespace Spect.Net.Assembler.Assembler
             }
         }
 
-        #endregion
+        #endregion Parsing and Directive processing
 
         #region Helpers
 
         /// <summary>
         /// Translates a Z80AsmParserErrorInfo instance into an error
         /// </summary>
-        private void ReportError(Z80AsmParserErrorInfo error)
+        /// <param name="sourceItem">Source file information, to allow the error to track the filename the error ocurred in</param>
+        private void ReportError(SourceFileItem sourceItem, Z80AsmParserErrorInfo error)
         {
-            _output.Errors.Add(new AssemblerErrorInfo(error));
+            _output.Errors.Add(new AssemblerErrorInfo(sourceItem, error));
         }
 
         /// <summary>
@@ -368,9 +368,10 @@ namespace Spect.Net.Assembler.Assembler
         /// <param name="parameters">Optiona error message parameters</param>
         private void ReportError(string errorCode, SourceLineBase line, params object[] parameters)
         {
-            _output.Errors.Add(new AssemblerErrorInfo(errorCode, line, parameters));
+            var sourceItem = _output.SourceFileList[line.FileIndex];
+            _output.Errors.Add(new AssemblerErrorInfo(sourceItem, errorCode, line, parameters));
         }
 
-        #endregion
+        #endregion Helpers
     }
 }

--- a/Tests/Spect.Net.Assembler.Test/Assembler/ErrorMessageTests.cs
+++ b/Tests/Spect.Net.Assembler.Test/Assembler/ErrorMessageTests.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using Spect.Net.Assembler.Assembler;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Spect.Net.Assembler.Test.Assembler
+{
+    [TestClass]
+    public class ErrorMessageTests : ParserTestBed
+    {
+        private const string TEST_FOLDER = "TestFiles";
+
+        [TestMethod]
+        public void Assemble_WhenAnErrorExistsInTheInitialFile_ShouldPutTHeInitialFilePathInTheError()
+        {
+            // --- Act
+            var output = Compile("ErrorsNoInclude.z80Asm");
+
+            // --- Assert
+            output.ErrorCount.ShouldBe(1);
+            Path.GetFileName(output.Errors.First().Filename).ShouldBe("ErrorsNoInclude.z80Asm");
+        }
+
+        [TestMethod]
+        public void Assemble_WhenAnErrorExistsInANestedIncludeFile_ShouldPutTheActualErrorFilePathInTheError()
+        {
+            // --- Act
+            var output = Compile("ErrorsInIncludedFilesLevel0.z80Asm");
+
+            // --- Assert
+            output.ErrorCount.ShouldBe(1);
+            Path.GetFileName(output.Errors.First().Filename).ShouldBe("ErrorsInIncludedFilesLevel2.z80Asm");
+        }
+
+        private AssemblerOutput Compile(string filename)
+        {
+            var folder = Path.GetDirectoryName(GetType().Assembly.Location) ?? string.Empty;
+            var fullname = Path.Combine(Path.Combine(folder, TEST_FOLDER), filename);
+
+            var asm = new Z80Assembler();
+            return asm.CompileFile(fullname);
+        }
+    }
+}

--- a/Tests/Spect.Net.Assembler.Test/Spect.Net.Assembler.Test.csproj
+++ b/Tests/Spect.Net.Assembler.Test/Spect.Net.Assembler.Test.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Assembler\BitOperationEmitTests.cs" />
     <Compile Include="Assembler\ControlFlowOperationEmitTests.cs" />
     <Compile Include="Assembler\DirectiveTests.cs" />
+    <Compile Include="Assembler\ErrorMessageTests.cs" />
     <Compile Include="Assembler\ExchangeOperationEmitTests.cs" />
     <Compile Include="Assembler\ExpressionEvaluationTests.cs" />
     <Compile Include="Assembler\FixupTests.cs" />
@@ -154,6 +155,18 @@
     </Content>
     <Content Include="TestFiles\Scenario2.inc21.z80Asm">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\ErrorsInIncludedFilesLevel0.z80asm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\ErrorsInIncludedFilesLevel1.z80asm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\ErrorsInIncludedFilesLevel2.z80asm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\ErrorsNoInclude.z80asm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel0.z80asm
+++ b/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel0.z80asm
@@ -1,0 +1,3 @@
+﻿;
+;
+#include "./ErrorsInIncludedFilesLevel1.z80Asm"

--- a/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel1.z80asm
+++ b/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel1.z80asm
@@ -1,0 +1,3 @@
+﻿;
+;
+#include "./ErrorsInIncludedFilesLevel2.z80Asm"

--- a/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel2.z80asm
+++ b/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsInIncludedFilesLevel2.z80asm
@@ -1,0 +1,2 @@
+﻿xor a
+ld n, chips

--- a/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsNoInclude.z80asm
+++ b/Tests/Spect.Net.Assembler.Test/TestFiles/ErrorsNoInclude.z80asm
@@ -1,0 +1,3 @@
+﻿ld a, 3
+ld z, q
+ld a, (hl)

--- a/VsIntegration/Spect.Net.VsPackage/Commands/RunZ80CodeCommand.cs
+++ b/VsIntegration/Spect.Net.VsPackage/Commands/RunZ80CodeCommand.cs
@@ -135,7 +135,7 @@ namespace Spect.Net.VsPackage.Commands
             const int timeOutInSeconds = 5;
             var counter = 0;
 
-            while (vm.VmState != VmState.Paused && counter < timeOutInSeconds*10)
+            while (vm.VmState != VmState.Paused && counter < timeOutInSeconds * 10)
             {
                 await Task.Delay(100);
                 counter++;
@@ -171,7 +171,7 @@ namespace Spect.Net.VsPackage.Commands
                     Category = TaskCategory.User,
                     ErrorCategory = TaskErrorCategory.Error,
                     HierarchyItem = Package.CodeManager.CurrentHierarchy,
-                    Document = ItemPath,
+                    Document = error.Filename ?? ItemPath,
                     Line = error.Line,
                     Column = error.Column,
                     Text = error.ErrorCode == null


### PR DESCRIPTION
I emailed (or am about to) you about this but I added the ability to double click on an error in visual studio and go to the included file that contains the error.