### PR TITLE
Removed hardcoded test path

### DIFF
--- a/Tests/Spect.Net.SpectrumEmu.Test/Spect.Net.SpectrumEmu.Test.csproj
+++ b/Tests/Spect.Net.SpectrumEmu.Test/Spect.Net.SpectrumEmu.Test.csproj
@@ -201,6 +201,9 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /S "$(SolutionDir)TBBlue\enNextOS.rom" "$(TargetDir)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/Spect.Net.SpectrumEmu.Test/Utility/RomSplitterTest.cs
+++ b/Tests/Spect.Net.SpectrumEmu.Test/Utility/RomSplitterTest.cs
@@ -8,13 +8,11 @@ namespace Spect.Net.SpectrumEmu.Test.Utility
     [TestClass]
     public class RomSplitterTest
     {
-        public const string SOURCEFILE =
-            @"C:\Users\dotne\source\repos\spectnetide\TBBlue\enNextOS.rom";
-
         [TestMethod]
+        [DeploymentItem("enNextOS.rom")]
         public void SplitRomFile()
         {
-            var fullRom = File.ReadAllBytes(SOURCEFILE);
+            var fullRom = File.ReadAllBytes("enNextOS.rom");
             for (var i = 0; i < 4; i++)
             {
                 var rom = fullRom.Skip(i * 0x4000).Take(0x4000).ToArray();
@@ -24,13 +22,14 @@ namespace Spect.Net.SpectrumEmu.Test.Utility
         }
 
         [TestMethod]
+        [DeploymentItem("enNextOS.rom")]
         public void SearchForBadMmc()
         {
             //var pattern = new byte[] {0x6D, 0x6D, 0x63, 0x2E, 0x72};
             var pattern = new byte[] { 0xC8, 0x3D };
             var matchIdx = 0;
             var startAddr = 0;
-            var fullRom = File.ReadAllBytes(SOURCEFILE);
+            var fullRom = File.ReadAllBytes("enNextOS.rom");
             for (var i = 0; i < fullRom.Length - 10; i++)
             {
                 if (pattern[matchIdx] != fullRom[i])


### PR DESCRIPTION
Removed hardcoded test path in favour of a deployment item.

Sadly VS variables are not expanded in DeploymentItem otherwise an attribute like this would be easier than using the xcopy post-build event:

`[DeploymentItem("$(SolutionDir)\TBBlue\enNextOS.rom")]`