### PR TITLE
Cloxk.zxbas typo fix

### DIFF
--- a/docs/_posts/getting-started/2019-10-01-use-zx-basic.md
+++ b/docs/_posts/getting-started/2019-10-01-use-zx-basic.md
@@ -43,7 +43,7 @@ Let's create a new ZX BASIC program!
 {:start="2"}
 2. Select the __ZX BASIC Program__ item type, set the name to `Clock.zxbas`, and click __Add__.
 
-3. Type (copy) this code into the new `Cloxk.zxbas` file:
+3. Type (copy) this code into the new `Clock.zxbas` file:
 
 ```
 CLS

--- a/docs/_site/feed.xml
+++ b/docs/_site/feed.xml
@@ -42,7 +42,7 @@ print at 4,6; ink 7; paper 1; flash 1;&quot; HELLO, ZX BASIC! &quot;
     &lt;p&gt;Select the &lt;strong&gt;ZX BASIC Program&lt;/strong&gt; item type, set the name to &lt;code class=&quot;highlighter-rouge&quot;&gt;Clock.zxbas&lt;/code&gt;, and click &lt;strong&gt;Add&lt;/strong&gt;.&lt;/p&gt;
   &lt;/li&gt;
   &lt;li&gt;
-    &lt;p&gt;Type (copy) this code into the new &lt;code class=&quot;highlighter-rouge&quot;&gt;Cloxk.zxbas&lt;/code&gt; file:&lt;/p&gt;
+    &lt;p&gt;Type (copy) this code into the new &lt;code class=&quot;highlighter-rouge&quot;&gt;Clock.zxbas&lt;/code&gt; file:&lt;/p&gt;
   &lt;/li&gt;
 &lt;/ol&gt;
 


### PR DESCRIPTION
Fix for the small typo I've noticed in one of the pages - https://dotneteer.github.io/spectnetide/getting-started/use-zx-basic#article. 

Not sure if the web page is linked with those docs here but since those have the same typo, I've provided the fix there.

Not sure also if feed.xml is generated but also fixed the typo there as well.