### PR TITLE
Update Z80BitOperations.cs

### DIFF
--- a/Core/Spect.Net.SpectrumEmu/Cpu/Z80BitOperations.cs
+++ b/Core/Spect.Net.SpectrumEmu/Cpu/Z80BitOperations.cs
@@ -2114,7 +2114,7 @@ namespace Spect.Net.SpectrumEmu.Cpu
         private void SRL_HLi()
         {
             var srlVal = ReadMemory(_registers.HL);
-            _registers.F = s_RlCarry0Flags[srlVal];
+            _registers.F = s_RrCarry0Flags[srlVal];
             srlVal >>= 1;
             if (UseGateArrayContention)
             {


### PR DESCRIPTION
SRL_HLi is using the Rl flags instead of the Rr ones, this causes the C flag to become the left-most bit instead of the right-most one.