### PR TITLE
Update for next ZX Basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 2.0.9 (Preview 11)
+__FIX__: Fixed random exception when using Visual Studio.
+__FEATURE__: Added support latest ZX Basic version (experimental)
+
 ### Version 2.0.9 (Preview 10)
 __FIX__: Fixed SRL instruction when using (HL) as target.
 __FIX__: Emulator windows distortion fixed.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 **Besides SpectNetIDE, I'm actively working on bringing a similar experience to Visual Studio Code with [Klive IDE](https://github.com/Dotneteer/kliveide). In the future, though I still maintain this project, I focus on Klive IDE.**
 
+## Version 2.0 (Preview 11) released
+
+This is a service version including:
+
+- __Fix for random exception in Visual Studio.
+- __Support for the next incomming ZX Basic version.
+
+For more info check the changelog.
+
+You can download the V2.0-preview 11 VSIX installer from the [Releases page](https://github.com/Dotneteer/spectnetide/releases).
+
 ## Version 2.0 (Preview 10) released
 
 This is a cumulative release including many fixes:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 This is a service version including:
 
-- __Fix for random exception in Visual Studio.
-- __Support for the next incomming ZX Basic version.
+- __Fix for random exception in Visual Studio.__
+- __Support for the next incomming ZX Basic version.__
 
 For more info check the changelog.
 
@@ -17,9 +17,9 @@ You can download the V2.0-preview 11 VSIX installer from the [Releases page](htt
 
 This is a cumulative release including many fixes:
 
-- __Support for latest ZX Basic versions.
-- __Improved performance.
-- __Corrected multiple problems.
+- __Support for latest ZX Basic versions.__
+- __Improved performance.__
+- __Corrected multiple problems.__
 
 For more info check the changelog.
 

--- a/v2/VsIntegration/Spect.Net.VsPackage/Commands/CreateVfddFileCommand.cs
+++ b/v2/VsIntegration/Spect.Net.VsPackage/Commands/CreateVfddFileCommand.cs
@@ -30,6 +30,9 @@ namespace Spect.Net.VsPackage.Commands
         /// <param name="mc"></param>
         protected override void OnQueryStatus(OleMenuCommand mc)
         {
+            base.OnQueryStatus(mc);
+            if (!mc.Visible) return;
+
             mc.Visible = SpectNetPackage.Default.EmulatorViewModel.Machine.SpectrumVm.FloppyDevice is FloppyDevice;
         }
 

--- a/v2/VsIntegration/Spect.Net.VsPackage/Commands/CreateVfddFileCommand.cs
+++ b/v2/VsIntegration/Spect.Net.VsPackage/Commands/CreateVfddFileCommand.cs
@@ -31,9 +31,11 @@ namespace Spect.Net.VsPackage.Commands
         protected override void OnQueryStatus(OleMenuCommand mc)
         {
             base.OnQueryStatus(mc);
-            if (!mc.Visible) return;
 
-            mc.Visible = SpectNetPackage.Default.EmulatorViewModel.Machine.SpectrumVm.FloppyDevice is FloppyDevice;
+            if (!mc.Visible) 
+                return;
+
+            mc.Visible = (SpectNetPackage.Default?.EmulatorViewModel?.Machine?.SpectrumVm?.FloppyDevice ?? (object)null) is FloppyDevice;
         }
 
         /// <summary>

--- a/v2/VsIntegration/Spect.Net.VsPackage/Compilers/ZxBasicCompiler.cs
+++ b/v2/VsIntegration/Spect.Net.VsPackage/Compilers/ZxBasicCompiler.cs
@@ -3,8 +3,10 @@ using Spect.Net.VsPackage.SolutionItems;
 using Spect.Net.VsPackage.VsxLibrary;
 using Spect.Net.VsPackage.VsxLibrary.Output;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -17,6 +19,322 @@ namespace Spect.Net.VsPackage.Compilers
     /// </summary>
     public class ZxBasicCompiler : ICompilerService
     {
+
+        private class ZxBasicNamespacePreprocessor
+        {
+            private class NamespaceSegment
+            {
+                public class ParsedLabel
+                {
+                    string matchPattern;
+
+                    public string OriginalName { get; private set; }
+                    public string NameOnNamespace { get; private set; }
+
+                    public ParsedLabel(string OriginalName, string NameOnNamespace)
+                    {
+                        this.OriginalName = OriginalName;
+                        this.NameOnNamespace = NameOnNamespace;
+                        matchPattern = $"(^|[\\s,\\(])({OriginalName})([\\s,:\\)]|$)";
+                    }
+
+                    public string ParseSentence(string Sentence)
+                    {
+                        return Regex.Replace(Sentence, matchPattern, $"$1{NameOnNamespace}$3");
+                    }
+                }
+
+                List<ParsedLabel> globalLabels = new List<ParsedLabel>();
+                Regex labelReg = new Regex("^\\s*?([-_a-zA-Z0-9][-_\\.a-zA-Z0-9]*?)\\s?(:|EQU)", RegexOptions.IgnoreCase);
+
+                public string SegmentName { get; private set; }
+                public string SegmentPath { get; private set; }
+                public string ParentPath { get; private set; }
+
+                public NamespaceSegment(string ParentPath, string SegmentName)
+                {
+                    this.SegmentName = SegmentName;
+                    this.ParentPath = ParentPath;
+
+                    SegmentPath = (string.IsNullOrWhiteSpace(ParentPath) ? "." : ParentPath) + SegmentName + ".";
+                }
+                public void ScanSentence(string Sentence, IEnumerable<AssemblerProcedure> ProcStac)
+                {
+                    var m = labelReg.Match(Sentence);
+
+                    if (m != null && m.Success && !string.IsNullOrWhiteSpace(m.Groups[1].Value))
+                    {
+                        string labelValue = m.Groups[1].Value;
+
+                        if (ProcStac != null && ProcStac.Any(p => p.IsLocal(labelValue)))
+                            return;
+
+                        string fullName = $"{SegmentPath}{m.Groups[1].Value}";
+                        if (!globalLabels.Any(l => l.NameOnNamespace == fullName))
+                        {
+                            ParsedLabel label = new ParsedLabel(m.Groups[1].Value, fullName);
+                            globalLabels.Add(label);
+                        }
+
+                    }
+                }
+                public string ParseSentence(string Sentence, IEnumerable<AssemblerProcedure> ProcStac)
+                {
+
+                    string parsedSentence = Sentence;
+
+                    foreach (var label in globalLabels)
+                    {
+                        if (ProcStac == null || !ProcStac.Any(p => p.IsLocal(label.OriginalName)))
+                            parsedSentence = label.ParseSentence(parsedSentence);
+                    }
+
+                    return parsedSentence;
+
+                }
+                public void AddLabel(string Label)
+                {
+                    ParsedLabel label = new ParsedLabel(Label, $"{SegmentPath}{Label}");
+                    globalLabels.Add(label);
+                }
+            }
+            private class AssemblerProcedure
+            {
+                Regex localLabelReg = new Regex("^\\s*?LOCAL\\s", RegexOptions.IgnoreCase);
+
+                List<string> localLabels = new List<string>();
+
+                public int ProcLineNumber { get; private set; }
+
+                public AssemblerProcedure(int LineNumber)
+                {
+                    ProcLineNumber = LineNumber;
+                }
+
+                public void ScanSentence(string Sentence)
+                {
+                    Match m = localLabelReg.Match(Sentence);
+
+                    if (m != null && m.Success)
+                    {
+                        var parts = Sentence.Split(", \r\n\t".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Skip(1);
+                        localLabels.AddRange(parts);
+                    }
+                }
+
+                public bool IsLocal(string Label)
+                {
+                    return localLabels.IndexOf(Label) != -1;
+                }
+            }
+
+            Regex pushReg = new Regex("^\\s*?push namespace ([\\._a-zA-Z0-9]*)", RegexOptions.IgnoreCase);
+            Regex popReg = new Regex("^\\s*?pop namespace", RegexOptions.IgnoreCase);
+            Regex procReg = new Regex("^\\s*?PROC\\s*$", RegexOptions.IgnoreCase);
+            Regex endProcReg = new Regex("^\\s*?ENDP\\s*$", RegexOptions.IgnoreCase);
+            Regex forcedNamespacelabelReg = new Regex("^\\s*?(\\.[-_\\.a-zA-Z0-9]*?)\\s?(:|EQU)", RegexOptions.IgnoreCase);
+
+            NamespaceSegment currentSegment;
+            Stack<NamespaceSegment> segments = new Stack<NamespaceSegment>();
+
+            AssemblerProcedure currentProc;
+            Stack<AssemblerProcedure> procs = new Stack<AssemblerProcedure>();
+
+            List<NamespaceSegment> storedSegments = new List<NamespaceSegment>();
+            List<AssemblerProcedure> storedProcs = new List<AssemblerProcedure>();
+
+            string content;
+
+            public ZxBasicNamespacePreprocessor(string FileContent)
+            {
+                content = FileContent;
+            }
+
+            public string ProcessContent()
+            {
+                storedSegments.Clear();
+                storedProcs.Clear();
+                segments.Clear();
+                procs.Clear();
+                currentProc = null;
+                currentSegment = null;
+
+                Match m;
+                string line;
+
+                StringBuilder sb = new StringBuilder();
+
+                using (StringReader sr = new StringReader(content))
+                {
+                    int cnt = 0;
+
+                    while ((line = sr.ReadLine()) != null)
+                    {
+                        cnt++;
+
+                        m = pushReg.Match(line);
+
+                        if (m != null && m.Success && !string.IsNullOrWhiteSpace(m.Groups[1].Value))
+                        {
+                            PushNamespaceSegment(m.Groups[1].Value);
+                            continue;
+                        }
+
+                        if (popReg.IsMatch(line))
+                        {
+                            PopNamespaceSegment();
+                            continue;
+                        }
+
+                        if (procReg.IsMatch(line))
+                        {
+                            PushStoreProc(cnt);
+                            continue;
+                        }
+
+                        if (endProcReg.IsMatch(line))
+                        {
+                            PopProc();
+                            continue;
+                        }
+
+                        m = forcedNamespacelabelReg.Match(line);
+
+                        if (m != null && m.Success && !string.IsNullOrWhiteSpace(m.Groups[1].Value))
+                        {
+                            var pathParts = m.Groups[1].Value.Split(".".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+
+                            string lastNamespace = pathParts[0];
+                            string label = pathParts.Last();
+                            string path = "." + string.Join(".", pathParts.Skip(1).Take(pathParts.Length - 2)) + ".";
+
+                            if (path == "..")
+                                path = "";
+
+                            var namespaceSegment = storedSegments.Where(ss => ss.SegmentName == lastNamespace && ss.ParentPath == path).FirstOrDefault();
+
+                            if (namespaceSegment == null)
+                            {
+                                namespaceSegment = new NamespaceSegment(path, lastNamespace);
+                                storedSegments.Add(namespaceSegment);
+                            }
+
+                            namespaceSegment.AddLabel(label);
+
+                        }
+
+                        if (currentProc != null)
+                            currentProc.ScanSentence(line);
+
+                        if (currentSegment != null)
+                            currentSegment.ScanSentence(line, procs);
+
+                        if (line.Contains("__PRINT_INIT"))
+                            line = line;
+
+                    }
+                }
+
+                segments.Clear();
+                procs.Clear();
+
+                using (StringReader sr = new StringReader(content))
+                {
+                    int cnt = 0;
+
+                    while ((line = sr.ReadLine()) != null)
+                    {
+                        cnt++;
+
+                        m = pushReg.Match(line);
+
+                        if (m != null && m.Success && !string.IsNullOrWhiteSpace(m.Groups[1].Value))
+                        {
+                            PushNamespaceSegment(m.Groups[1].Value);
+                            continue;
+                        }
+
+                        if (popReg.IsMatch(line))
+                        {
+                            PopNamespaceSegment();
+                            continue;
+                        }
+
+                        if (procReg.IsMatch(line))
+                        {
+                            PushExistingProc(cnt);
+                            sb.AppendLine(line);
+                            continue;
+                        }
+
+                        if (endProcReg.IsMatch(line))
+                        {
+                            PopProc();
+                            sb.AppendLine(line);
+                            continue;
+                        }
+
+                        if (currentSegment != null)
+                            line = currentSegment.ParseSentence(line, procs);
+
+                        sb.AppendLine(line);
+
+                    }
+                }
+
+                return sb.ToString();
+            }
+
+            private void PopProc()
+            {
+                procs.Pop();
+
+                if (procs.Count > 0)
+                    currentProc = procs.Peek();
+                else
+                    currentProc = null;
+            }
+
+            private void PushExistingProc(int cnt)
+            {
+                currentProc = storedProcs.Where(p => p.ProcLineNumber == cnt).FirstOrDefault();
+                procs.Push(currentProc);
+            }
+
+            private void PushStoreProc(int cnt)
+            {
+                currentProc = new AssemblerProcedure(cnt);
+                procs.Push(currentProc);
+                storedProcs.Add(currentProc);
+            }
+
+            private void PushNamespaceSegment(string NamespaceSegment)
+            {
+
+                currentSegment = storedSegments.Where(s => s.SegmentName == NamespaceSegment && s.ParentPath == (currentSegment?.SegmentPath ?? "")).FirstOrDefault();
+
+                if (currentSegment == null)
+                {
+                    currentSegment = new NamespaceSegment(currentSegment?.SegmentPath ?? "", NamespaceSegment);
+                    storedSegments.Add(currentSegment);
+                }
+
+                segments.Push(currentSegment);
+
+            }
+
+            private void PopNamespaceSegment()
+            {
+                var segment = segments.Pop();
+
+                if (segments.Count > 0)
+                    currentSegment = segments.Peek();
+                else
+                    currentSegment = null;
+            }
+
+        }
+
         private const string ZXB_NOT_FOUND_MESSAGE =
             "SpectNetIDE cannot run ZXBC.EXE ({0}). Please check that you specified the " +
             "correct path in the Spect.Net IDE options page (ZXB utility path) or added it " +
@@ -124,7 +442,10 @@ namespace Spect.Net.VsPackage.Compilers
             }
 
             var asmContents = File.ReadAllText(zxbOptions.OutputFilename);
-            asmContents = "\t.zxbasic\r\n" + asmContents;
+
+            ZxBasicNamespacePreprocessor preProc = new ZxBasicNamespacePreprocessor(asmContents);
+
+            asmContents = "\t.zxbasic\r\n" + preProc.ProcessContent();
             var hasHeapSizeLabel = Regex.Match(asmContents, "ZXBASIC_HEAP_SIZE\\s+EQU");
             if (!hasHeapSizeLabel.Success)
             {

--- a/v2/VsIntegration/Spect.Net.VsPackage/Spect.Net.VsPackage.csproj
+++ b/v2/VsIntegration/Spect.Net.VsPackage/Spect.Net.VsPackage.csproj
@@ -51,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CodeDiscoverProjectTreePropertiesProvider.cs" />

--- a/v2/VsIntegration/Spect.Net.VsPackage/SpectNetPackage.cs
+++ b/v2/VsIntegration/Spect.Net.VsPackage/SpectNetPackage.cs
@@ -55,7 +55,7 @@ namespace Spect.Net.VsPackage
     [InstalledProductRegistration(
         "#110", 
         "#112", 
-        "2.0.10", 
+        "2.0.11", 
         IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideAutoLoad(UIContextGuids.SolutionExists, PackageAutoLoadFlags.BackgroundLoad)]
@@ -163,7 +163,7 @@ namespace Spect.Net.VsPackage
         /// </summary>
         public const string CPS_FOLDER = @"CustomProjectSystems\Spect.Net.CodeDiscover";
         public const string CPS_VERSION_FILE = "cps.version";
-        public const string CURRENT_CPS_VERSION = "2.0.10";
+        public const string CURRENT_CPS_VERSION = "2.0.11";
         public const string CPS_RESOURCE_PREFIX = "Spect.Net.ProjectResources";
         public const string CPS_RULES = "Rules";
 

--- a/v2/VsIntegration/Spect.Net.VsPackage/source.extension.vsixmanifest
+++ b/v2/VsIntegration/Spect.Net.VsPackage/source.extension.vsixmanifest
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Spect.Net.VsPackage.E4F1ECA8-963F-4E73-8205-CDB1E484BA09" Version="2.0.10" Language="en-US" Publisher="Istvan Novak" />
-        <DisplayName>SpectNetIde 2.0 (Preview 10)</DisplayName>
+        <Identity Id="Spect.Net.VsPackage.E4F1ECA8-963F-4E73-8205-CDB1E484BA09" Version="2.0.11" Language="en-US" Publisher="Istvan Novak" />
+        <DisplayName>SpectNetIde 2.0 (Preview 11)</DisplayName>
         <Description xml:space="preserve">ZX Spectrum IDE with Visual Studio 2019 integration</Description>
         <Icon>Resources\SpectNetIde.ico</Icon>
         <Preview>true</Preview>


### PR DESCRIPTION
This revision adds support for the new features of ZX Basic: namespaces.

It adds the support as a preprocesor that takes care to reconstruct the labels according to the active namespace.

It also contains a small patch for a random exception that happens when VS scans for extensions (randomly in the output pane you can find a NullReferenceException thrown from CreateVfddFileCommand.cs).