### PR TITLE
Not listed issue: Missed project unsubscription from HierarchyEvent

### DIFF
--- a/v2/VsIntegration/Spect.Net.VsPackage/SolutionItems/SolutionStructure.cs
+++ b/v2/VsIntegration/Spect.Net.VsPackage/SolutionItems/SolutionStructure.cs
@@ -172,6 +172,13 @@ namespace Spect.Net.VsPackage.SolutionItems
                     }
                 }
 
+                // Before we reassign HierarchyItems to new collection 
+                // we have to call Dispose manually for all previous items, to unsibscribe from HierarchyEvents
+                foreach(SpectrumProject proj in HierarchyItems)
+                {
+                    proj.Dispose();
+                }
+
                 HierarchyItems = collectedItems;
                 Projects = new ReadOnlyCollection<SpectrumProject>(HierarchyItems);
                 var contents = File.ReadAllText(Path.Combine(SolutionDir, PRIVATE_FOLDER, SETTINGS_FILE));


### PR DESCRIPTION
Added Dispose() call for ProjectItems in SolutionStructure. Without it old projects items still have subscription to HierarchyEvent and they had to proceed any changes in hierarchy and led to "VS not responding" state